### PR TITLE
feat: add prometheus client with register ws-counter

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -43,6 +43,7 @@
     "nanoid": "3.1.12",
     "pino": "6.7.0",
     "pino-pretty": "4.3.0",
+    "prom-client": "13.1.0",
     "ws": "7.4.3"
   },
   "devDependencies": {

--- a/packages/gateway/src/heartbeat.ts
+++ b/packages/gateway/src/heartbeat.ts
@@ -7,6 +7,7 @@ import { WebSocket } from './types';
 
 export type HeartbeatController = {
   addConnection(connectionId: string, connection: WebSocket): void;
+  getAliveConnections(): number;
   stop(): void;
 };
 
@@ -14,10 +15,10 @@ export function setupPingConnections(
   wss: Server,
   heartbeatInterval: number,
 ): HeartbeatController {
-  const connectionsMap: WeakMap<
+  const connectionsMap: Map<
     WebSocket,
     { isAlive: boolean; id: string }
-  > = new WeakMap();
+  > = new Map();
 
   function heartbeat(this: WebSocket) {
     const wsMeta = connectionsMap.get(this);
@@ -51,6 +52,11 @@ export function setupPingConnections(
     addConnection: (connectionId: string, connection: WebSocket) => {
       connectionsMap.set(connection, { isAlive: true, id: connectionId });
       connection.on('pong', heartbeat);
+    },
+    getAliveConnections: () => {
+      return Array.from(connectionsMap.values()).filter(
+        (connection) => connection.isAlive,
+      ).length;
     },
     stop: () => clearInterval(iid),
   };

--- a/packages/platform-gateway/package.json
+++ b/packages/platform-gateway/package.json
@@ -38,7 +38,8 @@
     "cors": "2.8.5",
     "engine.io": "4.1.1",
     "env-schema": "2.0.1",
-    "express": "4.17.1"
+    "express": "4.17.1",
+    "prom-client": "13.1.0"
   },
   "devDependencies": {
     "@dlghq/grpc-web-gateway-signaling": "^4.0.9",

--- a/packages/platform-gateway/src/index.ts
+++ b/packages/platform-gateway/src/index.ts
@@ -18,6 +18,7 @@ import {
   createGrpcGatewayMiddlewares,
   HttpRequestMiddleware,
 } from '@dlghq/grpc-web-gateway';
+import { register } from 'prom-client';
 
 console.log(`Starting gateway version: ${packageInfo.version}`);
 
@@ -96,6 +97,15 @@ function createWebAppMiddleware(): HttpRequestMiddleware {
         version: packageInfo.version,
       },
     });
+  });
+
+  app.get('/metrics', async (req, res) => {
+    try {
+      res.set('Content-Type', register.contentType);
+      res.end(await register.metrics());
+    } catch (ex) {
+      res.status(500).end(ex);
+    }
   });
 
   return () => app;


### PR DESCRIPTION
На данном примере можно увидеть как отображалась бы метрика (но не лучшая визуализация для данной величины)
![image](https://user-images.githubusercontent.com/14920978/116398551-98c6e400-a830-11eb-8cff-8e1a32c542c0.png)

есть вопросы на повестку
@a-shabanov 
1) Добавить ли дефолтные метрики с ноды?
2) Хотим ли каунтить ошибки? вообще там вроде как можем метрику на каждый тип накидать, после чего построить график где каждый тип отслеживать (но непонятно какую информацию это даст)